### PR TITLE
Add DynamicHostTest2. Minor fixes in DynamicHostTest.

### DIFF
--- a/DynamicHostTest/DynamicHostTest/SubWorker.cs
+++ b/DynamicHostTest/DynamicHostTest/SubWorker.cs
@@ -28,9 +28,9 @@ namespace DynamicHostTest
             _logger.LogInformation("SubWorker {string} starting.", _subWorkerString, DateTimeOffset.Now);
 
             var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _taskCancellationTokenSource.Token);
-            linkedCancellationTokenSource.Token.Register(() => _logger.LogDebug("SubWorker {string} linkkedCancellationToken canceled."));
+            linkedCancellationTokenSource.Token.Register(() => _logger.LogDebug("SubWorker {string} linkedCancellationToken canceled.", _subWorkerString));
 
-            var task =Task.Run(async () =>
+            var task= Task.Run(async () =>
             {
                 try
                 {

--- a/DynamicHostTest2/DynamicHostTest2.sln
+++ b/DynamicHostTest2/DynamicHostTest2.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29609.76
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicHostTest2", "DynamicHostTest2\DynamicHostTest2.csproj", "{BA173F11-6BF5-4EBF-ACE7-AA0A1C213BDD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BA173F11-6BF5-4EBF-ACE7-AA0A1C213BDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA173F11-6BF5-4EBF-ACE7-AA0A1C213BDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA173F11-6BF5-4EBF-ACE7-AA0A1C213BDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA173F11-6BF5-4EBF-ACE7-AA0A1C213BDD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8B885829-242A-43C9-B5C4-9CD1A203810D}
+	EndGlobalSection
+EndGlobal

--- a/DynamicHostTest2/DynamicHostTest2/DynamicHostTest2.csproj
+++ b/DynamicHostTest2/DynamicHostTest2/DynamicHostTest2.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UserSecretsId>dotnet-DynamicHostTest2-0A93A255-2831-4482-B33A-CDF1F6C95938</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
+  </ItemGroup>
+</Project>

--- a/DynamicHostTest2/DynamicHostTest2/Minion.cs
+++ b/DynamicHostTest2/DynamicHostTest2/Minion.cs
@@ -1,0 +1,13 @@
+﻿namespace DynamicHostTest2
+{
+    public class Minion
+    {
+        public string Name { get; set; }
+
+        public Minion()
+        {
+        }
+
+
+    }
+}

--- a/DynamicHostTest2/DynamicHostTest2/Program.cs
+++ b/DynamicHostTest2/DynamicHostTest2/Program.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace DynamicHostTest2
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((hostingContext, config) => { config.AddConfiguration(new ConfigurationBuilder().AddJsonFile("appsettings.json").Build()); })
+                .ConfigureLogging(logging =>
+                {
+                    logging.ClearProviders();
+                    logging.AddConsole();
+                })
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddHostedService<Worker>();
+                    services.AddTransient<SelfHostA>();
+                })
+                ;
+    }
+}

--- a/DynamicHostTest2/DynamicHostTest2/Properties/launchSettings.json
+++ b/DynamicHostTest2/DynamicHostTest2/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+﻿{
+  "profiles": {
+    "DynamicHostTest2": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/DynamicHostTest2/DynamicHostTest2/SelfHostA.cs
+++ b/DynamicHostTest2/DynamicHostTest2/SelfHostA.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace DynamicHostTest2
+{
+    public class SelfHostA : IHostedService, IDisposable
+    {
+        private readonly ILogger<SelfHostA> _logger;
+        private CancellationTokenSource _taskCancellationTokenSource;
+        private readonly IHost _host;
+
+        public SelfHostA()
+        {
+            _host = CreateHostBuilder().Build();
+            _host.RunAsync();
+            _logger = _host.Services.GetRequiredService<ILogger<SelfHostA>>();
+        }
+
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("SelfHostA  starting host.");
+
+            _taskCancellationTokenSource=new CancellationTokenSource();
+            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _taskCancellationTokenSource.Token);
+            _taskCancellationTokenSource.Token.Register(() => _logger.LogDebug("_taskCancellationTokenSource token cancelled."));
+
+            var m1 = _host.Services.GetRequiredService<Minion>();
+            m1.Name = "Bruce";
+            _logger.LogDebug($"SelfHostA  created a minion named {m1.Name}");
+
+            var task = Task.Run(async () =>
+            {
+                while (!_taskCancellationTokenSource.Token.IsCancellationRequested)
+                {
+                    _logger.LogDebug("SelfHostA is running.");
+                    await Task.Delay(1000);
+                }
+            },_taskCancellationTokenSource.Token).ContinueWith((s)=>_logger.LogDebug("SelfHostA task loop stopped."));
+
+            await Task.CompletedTask;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("SelfHostA  stopping host.");
+            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _taskCancellationTokenSource.Token);
+
+            _taskCancellationTokenSource.Cancel();
+        }
+
+        public static IHostBuilder CreateHostBuilder() =>
+            Host.CreateDefaultBuilder()
+                .ConfigureAppConfiguration((hostingContext, config) => { config.AddConfiguration(new ConfigurationBuilder().AddJsonFile("appsettings_subworker.json").Build()); })
+                .ConfigureLogging(logging =>
+                {
+                    logging.ClearProviders();
+                    logging.AddConsole();
+                })
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddTransient<Minion>();
+
+                })
+        ;
+
+        public void Dispose()
+        {
+            _host?.Dispose();
+            _taskCancellationTokenSource?.Dispose();
+        }
+    }
+}

--- a/DynamicHostTest2/DynamicHostTest2/appsettings.Development.json
+++ b/DynamicHostTest2/DynamicHostTest2/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/DynamicHostTest2/DynamicHostTest2/appsettings.json
+++ b/DynamicHostTest2/DynamicHostTest2/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/DynamicHostTest2/DynamicHostTest2/appsettings_subworker.json
+++ b/DynamicHostTest2/DynamicHostTest2/appsettings_subworker.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}


### PR DESCRIPTION
Adds new solution like DynamicHostTest except instead of creating SubWorker objects, Worker gets injected a service that it can start and stop but which has its own internal IHost that it wires up itself.